### PR TITLE
test furo-sphinx design integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+_build
 
 # PyBuilder
 target/

--- a/conf.py
+++ b/conf.py
@@ -7,6 +7,7 @@
 extensions = [
     "sphinx.ext.intersphinx",
     "myst_parser",
+    "sphinx_design",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -25,11 +26,11 @@ myst_enable_extensions = [
 master_doc = "index"
 
 # General information about the project.
-project = "Sphinx Primer"
+project = "Sphinx Playground"
 copyright = "2021, Oriol Abril-Pla"
 author = "Oriol Abril-Pla"
 
-version = "0.2"
+version = "0.1"
 # The full version, including alpha/beta/rc tags.
 release = version
 
@@ -57,32 +58,11 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "pydata_sphinx_theme"
+html_theme = "furo"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-html_theme_options = {
-    "icon_links": [
-        {
-            "name": "GitHub",
-            "url": "https://github.com/OriolAbril",
-            "icon": "fab fa-github-square",
-        },
-        {
-            "name": "Twitter",
-            "url": "https://twitter.com/OriolAbril",
-            "icon": "fab fa-twitter-square",
-        },
-    ],
-    "use_edit_page_button": True,
-}
-html_context = {
-    "github_user": "OriolAbril",
-    "github_repo": "sphinx-playground",
-    "github_version": "main",
-    "doc_path": ".",
-}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/index.md
+++ b/index.md
@@ -1,1 +1,52 @@
 # Playground home
+
+Grid with dark/light only elements
+
+::::{grid} 3
+:::{grid-item-card}
+Regular element
+:::
+:::{grid-item-card}
+:class-item: only-light
+
+only-light
+:::
+:::{grid-item-card}
+Regular element 2
+^^^
+
+This element has a header and a body to test extra behaviour
+and alignment of grid items of different size, but
+it has no special classes and should be shown in both cases.
+:::
+:::{grid-item-card}
+:class-item: only-dark
+
+only-dark
+:::
+:::{grid-item-card}
+Regular element 3
+:::
+::::
+
+Grid with no special elements
+
+::::{grid} 3
+:::{grid-item-card}
+Regular element
+:::
+:::{grid-item-card}
+Regular element 2
+^^^
+
+This element has a header and a body to test extra behaviour
+and alignment of grid items of different size, but
+it has no special classes and should be shown in both cases.
+:::
+:::{grid-item-card}
+Regular item 2.5
+:::
+:::{grid-item-card}
+Regular element 3
+:::
+::::

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,6 +1,6 @@
 docutils
 Sphinx>=4
 myst-parser
-furo
-git+https://github.com/OriolAbril/sphinx-design@light_dark
+git+https://github.com/pradyunsg/furo
+sphinx-design
 

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,4 +1,5 @@
 docutils
 Sphinx>=4
-pydata_sphinx_theme>=0.6.3
 myst-parser
+furo
+sphinx-design

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -2,4 +2,5 @@ docutils
 Sphinx>=4
 myst-parser
 furo
-sphinx-design
+git+https://github.com/OriolAbril/sphinx-design@light_dark
+


### PR DESCRIPTION
This builds a playground page with the branch of sphinx-design with the changes
suggested in https://github.com/executablebooks/sphinx-design/issues/53, removing
the `!important` from sphinx-design display scss file.
